### PR TITLE
Add dummy requirements.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/requirements"
+    directory: "/"
     schedule:
       interval: "daily"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# This is just for Dependabot
+-r requirements/main.txt
+-r requirements/deploy.txt


### PR DESCRIPTION
This ensures dependabot keeps the right paths when regenerating requirements files.