### PR TITLE
chore: filter out health checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .state/
+__pycache__/


### PR DESCRIPTION
Sentry currently reports over 790k transactions per week, generated by `kube-probe` health checks.
This increases outbound network traffic, and isn't very helpful.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>