### PR TITLE
Add a mailto link generator to easily report malicious packages.

### DIFF
--- a/inspector/main.py
+++ b/inspector/main.py
@@ -48,7 +48,7 @@ def handle_bad_request(e):
 @app.route("/")
 def index():
     if project := request.args.get("project"):
-        return redirect(f"/project/{ project }")
+        return redirect(f"/project/{project}")
     return render_template("index.html")
 
 
@@ -78,7 +78,7 @@ def versions(project_name):
 def distributions(project_name, version):
     resp = requests.get(f"https://pypi.org/pypi/{project_name}/{version}/json")
     if resp.status_code != 200:
-        return redirect(f"/project/{ project_name }/")
+        return redirect(f"/project/{project_name}/")
 
     dist_urls = [
         "." + urllib.parse.urlparse(url["url"]).path + "/"
@@ -204,19 +204,23 @@ def mailto_report_link(project_name, version, file_path, request_url):
     """
     Generate a mailto report link for malicious code.
     """
-    message_body = "PyPI Malicious Package Report\n" \
-                   "--\n" \
-                   f"Package Name: {project_name}\n" \
-                   f"Version: {version}\n" \
-                   f"File Path: {file_path}\n" \
-                   f"Inspector URL: {request_url}\n\n" \
-                   "Additional Information:\n\n"
+    message_body = (
+        "PyPI Malicious Package Report\n"
+        "--\n"
+        f"Package Name: {project_name}\n"
+        f"Version: {version}\n"
+        f"File Path: {file_path}\n"
+        f"Inspector URL: {request_url}\n\n"
+        "Additional Information:\n\n"
+    )
 
     subject = f"Malicious Package Report: {project_name}"
 
-    return f"mailto:security@pypi.org?" \
-           f"subject={urllib.parse.quote(subject)}" \
-           f"&body={urllib.parse.quote(message_body)}"
+    return (
+        f"mailto:security@pypi.org?"
+        f"subject={urllib.parse.quote(subject)}"
+        f"&body={urllib.parse.quote(message_body)}"
+    )
 
 
 @app.route(

--- a/inspector/templates/code.html
+++ b/inspector/templates/code.html
@@ -5,6 +5,7 @@
 {% endblock %}
 
 {% block body %}
+<a href="{{ mailto_report_link }}" style="color:red"> <strong>Report Malicious Package</strong> </a>
 <pre id="line" class="line-numbers linkable-line-numbers language-python">
 <code class="language-python">{{- code }}</code>
 </pre>


### PR DESCRIPTION
Adds a "Report Malicious Package" anchor tag with a custom `mailto` URI pertaining to the package and current file.

## Screenshots

### Source Code View
<img width="919" alt="image" src="https://user-images.githubusercontent.com/43831545/231587362-7619fddc-01a4-4ec3-a7dd-af17177e33d6.png">

### Upon clicking the report link...
<img width="837" alt="image" src="https://user-images.githubusercontent.com/43831545/231587863-d464639a-0c08-416b-a180-5adfa2d1808e.png">


