### PR TITLE
Canonicalize project name and redirect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ serve: .state/docker-build
 #	docker-compose run --rm web flask db upgrade
 
 reformat:
-	docker-compose run --rm web isort -rc inspector #migrations
-	docker-compose run --rm web black inspector #migrations
+	docker-compose run --rm web bin/reformat $(T) $(TESTARGS)
 
 tests: .state/docker-build
 	docker-compose run --rm web bin/tests $(T) $(TESTARGS)

--- a/bin/reformat
+++ b/bin/reformat
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Click requires us to ensure we have a well configured environment to run
+# our click commands. So we'll set our environment to ensure our locale is
+# correct.
+export LC_ALL="${ENCODING:-en_US.UTF-8}"
+export LANG="${ENCODING:-en_US.UTF-8}"
+
+# Print all the following commands
+set -x
+
+python -m isort inspector/
+python -m black inspector/

--- a/inspector/legacy.py
+++ b/inspector/legacy.py
@@ -1,4 +1,5 @@
 import re
+
 from typing import Iterator, List, Tuple
 
 from packaging.version import InvalidVersion, Version, _BaseVersion

--- a/inspector/main.py
+++ b/inspector/main.py
@@ -5,10 +5,10 @@ import zipfile
 from io import BytesIO
 
 import gunicorn.http.errors
-from packaging.utils import canonicalize_name
 import requests
 import sentry_sdk
 from flask import Flask, Response, abort, redirect, render_template, request, url_for
+from packaging.utils import canonicalize_name
 from sentry_sdk.integrations.flask import FlaskIntegration
 
 from .legacy import parse

--- a/inspector/main.py
+++ b/inspector/main.py
@@ -2,11 +2,13 @@ import os
 import tarfile
 import urllib.parse
 import zipfile
+
 from io import BytesIO
 
 import gunicorn.http.errors
 import requests
 import sentry_sdk
+
 from flask import Flask, Response, abort, redirect, render_template, request, url_for
 from packaging.utils import canonicalize_name
 from sentry_sdk.integrations.flask import FlaskIntegration

--- a/inspector/main.py
+++ b/inspector/main.py
@@ -5,9 +5,10 @@ import zipfile
 from io import BytesIO
 
 import gunicorn.http.errors
+from packaging.utils import canonicalize_name
 import requests
 import sentry_sdk
-from flask import Flask, Response, abort, redirect, render_template, request
+from flask import Flask, Response, abort, redirect, render_template, request, url_for
 from sentry_sdk.integrations.flask import FlaskIntegration
 
 from .legacy import parse
@@ -54,6 +55,11 @@ def index():
 
 @app.route("/project/<project_name>/")
 def versions(project_name):
+    if project_name != canonicalize_name(project_name):
+        return redirect(
+            url_for("versions", project_name=canonicalize_name(project_name)), 301
+        )
+
     resp = requests.get(f"https://pypi.org/pypi/{project_name}/json")
     pypi_project_url = f"https://pypi.org/project/{project_name}"
 
@@ -76,6 +82,16 @@ def versions(project_name):
 
 @app.route("/project/<project_name>/<version>/")
 def distributions(project_name, version):
+    if project_name != canonicalize_name(project_name):
+        return redirect(
+            url_for(
+                "distributions",
+                project_name=canonicalize_name(project_name),
+                version=version,
+            ),
+            301,
+        )
+
     resp = requests.get(f"https://pypi.org/pypi/{project_name}/{version}/json")
     if resp.status_code != 200:
         return redirect(f"/project/{project_name}/")
@@ -176,6 +192,20 @@ def _get_dist(first, second, rest, distname):
     "/project/<project_name>/<version>/packages/<first>/<second>/<rest>/<distname>/"
 )
 def distribution(project_name, version, first, second, rest, distname):
+    if project_name != canonicalize_name(project_name):
+        return redirect(
+            url_for(
+                "distribution",
+                project_name=canonicalize_name(project_name),
+                version=version,
+                first=first,
+                second=second,
+                rest=rest,
+                distname=distname,
+            ),
+            301,
+        )
+
     dist = _get_dist(first, second, rest, distname)
 
     if dist:
@@ -227,6 +257,21 @@ def mailto_report_link(project_name, version, file_path, request_url):
     "/project/<project_name>/<version>/packages/<first>/<second>/<rest>/<distname>/<path:filepath>"  # noqa
 )
 def file(project_name, version, first, second, rest, distname, filepath):
+    if project_name != canonicalize_name(project_name):
+        return redirect(
+            url_for(
+                "file",
+                project_name=canonicalize_name(project_name),
+                version=version,
+                first=first,
+                second=second,
+                rest=rest,
+                distname=distname,
+                filepath=filepath,
+            ),
+            301,
+        )
+
     dist = _get_dist(first, second, rest, distname)
     if dist:
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.isort]
+profile = 'black'
+lines_between_types = 1
+combine_as_imports = true
+known_first_party = ['inspector']


### PR DESCRIPTION
This PR ensures inspector always redirects to a URL with a canonical project name.