### PR TITLE
Return FileNotFoundError when EOFError is raised

### DIFF
--- a/inspector/main.py
+++ b/inspector/main.py
@@ -157,7 +157,7 @@ class TarGzDistribution(Distribution):
                 return file_.read()
             else:
                 raise FileNotFoundError
-        except KeyError:
+        except (KeyError, EOFError):
             raise FileNotFoundError
 
 


### PR DESCRIPTION
Resolves https://python-software-foundation.sentry.io/issues/4296392432.

Problematic URL is https://inspector.pypi.io/project/airtable-to-sqlite/0.1.0/packages/a7/43/f4470171034172f45dbbfe176466dd20a2e8277e4628c5f8f58921dd4bd2/airtable_to_sqlite-0.1.0.tar.gz/airtable_to_sqlite-0.1.0/.venv/airtable-to-sqlite/Lib/site-packages/tqdm/contrib/telegram.py