### PR TITLE
Fix: Added line CSS ID whitespace rule

### DIFF
--- a/inspector/static/style.css
+++ b/inspector/static/style.css
@@ -14,3 +14,7 @@
     display: block;
     color: red;
 }
+
+#line {
+    white-space: break-spaces;
+}


### PR DESCRIPTION
Closes #144 

Significant whitespace overflows, such as those that may exist when many tabs or whitespace characters are intentionally inserted into the codebase, will now wrap to maintain a fixed width relative to the parent container.