### PR TITLE
fix: Text wrapping

### DIFF
--- a/inspector/static/prism.css
+++ b/inspector/static/prism.css
@@ -10,7 +10,9 @@ pre[class*=language-] {
     text-align: left;
     white-space: pre-wrap;
     word-spacing: normal;
-    word-break: normal;
+    word-break: break-word;
+    overflow: auto;
+    max-width: 100%;
     word-wrap: normal;
     line-height: 1.5;
     -moz-tab-size: 4;
@@ -49,7 +51,7 @@ pre[class*=language-]::selection {
 pre[class*=language-] {
     padding: 1em;
     margin: .5em 0;
-    overflow: normal;
+    overflow: auto;
 }
 
 :not(pre)>code[class*=language-],


### PR DESCRIPTION
Closes #144 

- Reimported Prism.js CSS. 
- Unminified CSS. 
- Added: 
```css
pre[class*="language-"] {
    overflow: auto;
    word-break: break-word;
    max-width: 100%;
```
- Proofed on 1366x768, 1920x1080, and 3840x2160 locally. 

Large diff is due to some linting nits, figured I'd throw them up here because I believe they're valid fixes that reflect CSS best practices. Let me know if you'd just rather I insert the above change instead.

Drawing attention to: 
- This causes some poor behavior on mobile. It attempts to keep the entire codebase on screen and wraps indiscriminately. I can set a min-width for this of something like 700px if mobile support is a concern. Given the role of this site, I figured I'd ask before committing that. 

- With exceptionally long text lines, this will not cause an intelligent hanging indent. There doesn't seem to be an effective way to do this with Prism, and we'd be looking towards running something like Black on the code prior to rendering it on screen if we wanted to intelligently replicate this behavior. (Which, honestly? I wouldn't complain about.) 

- In all of the above events, line numbers are appropriately preserved in comparison to the live Inspector site. 


