### PR TITLE
Do not wrap line numbers

### DIFF
--- a/inspector/static/prism.css
+++ b/inspector/static/prism.css
@@ -216,6 +216,8 @@ pre[class*=language-].line-numbers>code {
 }
 
 .line-numbers .line-numbers-rows {
+    word-wrap:normal;
+    word-break: keep-all;
     position: absolute;
     pointer-events: none;
     top: 0;

--- a/inspector/static/prism.css
+++ b/inspector/static/prism.css
@@ -216,7 +216,7 @@ pre[class*=language-].line-numbers>code {
 }
 
 .line-numbers .line-numbers-rows {
-    word-wrap:normal;
+    word-wrap: normal;
     word-break: keep-all;
     position: absolute;
     pointer-events: none;


### PR DESCRIPTION
Closes #147

Line numbers now utilize with a "keep all" and "wrap normal" flag to prevent wrapping of the line numbers. 