### PR TITLE
Created an HTML table-based "package releases" view.

### DIFF
--- a/inspector/main.py
+++ b/inspector/main.py
@@ -67,13 +67,15 @@ def versions(project_name):
     if resp.status_code != 200:
         return redirect(pypi_project_url, 307)
 
-    version_urls = [
-        "." + "/" + str(version)
-        for version in sorted(resp.json()["releases"].keys(), key=parse, reverse=True)
-    ]
+    releases = resp.json()["releases"]
+    sorted_releases = {
+        version: releases[version]
+        for version in sorted(releases.keys(), key=parse, reverse=True)
+    }
+
     return render_template(
-        "links.html",
-        links=version_urls,
+        "releases.html",
+        releases=sorted_releases,
         h2=project_name,
         h2_link=f"/project/{project_name}",
         h2_paren="View this project on PyPI",

--- a/inspector/static/style.css
+++ b/inspector/static/style.css
@@ -14,3 +14,13 @@
     display: block;
     color: red;
 }
+
+table, th, td {
+    border: 1px solid black;
+    border-collapse: collapse;
+    padding: 4px;
+}
+
+.no-entries {
+    color: grey;
+}

--- a/inspector/templates/releases.html
+++ b/inspector/templates/releases.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+
+{% block head %}
+  <link rel="stylesheet" type="text/css" href="/static/style.css">
+{% endblock %}
+
+{% block body %}
+{% if releases|length != 1 %}
+  <p>Retrieved {{ releases|length }} versions.</p>
+{% else %}
+  <p>Retrieved 1 version.</p>
+{% endif %}
+
+<table>
+<colgroup>
+  <col style="width: 160px">
+  <col style="width: 160px">
+  <col style="width: 160px">
+</colgroup>
+<thead>
+<tr>
+  <th>Version</th>
+  <th>Upload Timestamp</th>
+  <th>Artifacts</th>
+</tr>
+</thead>
+{% for key, value in releases.items() %}
+  <tr>
+  {% if value|length > 0 %}
+    <td><a href="./{{ key }}">{{ key }}</a></td>
+    <td>{{ value[0]['upload_time'] }}</td>
+    <td>{{ value|length }}</td>
+  {% else %}
+    <td>{{ key }}</td>
+    <td><span class="no-entries"><i>Not Available</i></span></td>
+    <td><span class="no-entries"><i>Not Available</i></span></td>
+  {% endif %}
+  </tr>
+{% endfor %}
+<tbody>
+</tbody>
+
+</table>
+
+{% endblock %}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,8 +20,8 @@ def test_versions(monkeypatch):
     assert get.calls == [pretend.call("https://pypi.org/pypi/foo/json")]
     assert render_template.calls == [
         pretend.call(
-            "links.html",
-            links=["./0.5.1e"],
+            "releases.html",
+            releases={"0.5.1e": None},
             h2="foo",
             h2_link="/project/foo",
             h2_paren="View this project on PyPI",


### PR DESCRIPTION
## Screenshots
Package releases are laid out in an HTML table. The "Upload Timestamp" column gets populated with the upload timestamp of the first artifact in the distribution (as returned by the pypi API).

![CleanShot 2023-11-29 at 17 56 30@2x](https://github.com/pypi/inspector/assets/43831545/c073a981-c6c1-490a-8248-25cd1afd795f)

For releases that do not contain any artifacts, the version anchor tag does not apply, and the other columns are populated with "Not available."

![CleanShot 2023-11-29 at 17 57 56@2x](https://github.com/pypi/inspector/assets/43831545/e06e2a59-ab1e-473c-b8ec-761f457fe61a)

Example used: `django`