### PR TITLE
feat: update report link to pypi form

### DIFF
--- a/inspector/main.py
+++ b/inspector/main.py
@@ -13,7 +13,7 @@ from .analysis.checks import basic_details
 from .deob import decompile, disassemble
 from .distribution import _get_dist
 from .legacy import parse
-from .utilities import mailto_report_link, pypi_report_form
+from .utilities import pypi_report_form
 
 
 def traces_sampler(sampling_context):

--- a/inspector/main.py
+++ b/inspector/main.py
@@ -13,7 +13,7 @@ from .analysis.checks import basic_details
 from .deob import decompile, disassemble
 from .distribution import _get_dist
 from .legacy import parse
-from .utilities import mailto_report_link
+from .utilities import mailto_report_link, pypi_report_form
 
 
 def traces_sampler(sampling_context):
@@ -205,7 +205,7 @@ def file(project_name, version, first, second, rest, distname, filepath):
         except FileNotFoundError:
             return abort(404)
         file_extension = filepath.split(".")[-1]
-        report_link = mailto_report_link(project_name, version, filepath, request.url)
+        report_link = pypi_report_form(project_name, version, filepath, request.url)
 
         details = [detail.html() for detail in basic_details(dist, filepath)]
         common_params = {

--- a/inspector/utilities.py
+++ b/inspector/utilities.py
@@ -22,3 +22,20 @@ def mailto_report_link(project_name, version, file_path, request_url):
         f"subject={urllib.parse.quote(subject)}"
         f"&body={urllib.parse.quote(message_body)}"
     )
+
+
+def pypi_report_form(project_name, version, file_path, request_url):
+    """
+    Generate a URL to PyPI malware report for malicious code.
+    """
+    summary = (
+        f"Version: {version}\n"
+        f"File Path: {file_path}\n"
+        "Additional Information:\n\n"
+    )
+
+    return (
+        f"https://pypi.org/project/{project_name}/submit-malware-report/"
+        f"?inspector_link={request_url}"
+        f"&summary={urllib.parse.quote(summary)}"
+    )


### PR DESCRIPTION
Instead of email, send to the report form.
I left the `mailto_report_link` function around in case we wanna flip back quickly.