### PR TITLE
FIX: Strip whitespace from project argument

### DIFF
--- a/inspector/main.py
+++ b/inspector/main.py
@@ -50,6 +50,7 @@ def handle_bad_request(e):
 @app.route("/")
 def index():
     if project := request.args.get("project"):
+        project = project.strip()
         return redirect(f"/project/{project}")
     return render_template("index.html")
 


### PR DESCRIPTION
Leading and trailing whitespace is invalid for project titles.

This change seeks to correct this behavior in the search parameter, since otherwise it will always result in an invalid project being returned. 