### PR TITLE
FIX: Report button does not expand to fill parent div

### DIFF
--- a/inspector/static/style.css
+++ b/inspector/static/style.css
@@ -11,7 +11,7 @@
 }
 
 .report-anchor {
-    display: block;
+    display: inline;
     color: red;
 }
 


### PR DESCRIPTION
At the moment, the CSS attribute defined for the report button will expand to fill the parent div. This causes the entire element to be clickable, and can cause users to unintentionally click the report button. 

![image](https://github.com/pypi/inspector/assets/128343390/43d8dcc4-d1a2-4727-b7c5-9613b128ef72)

Adjusting the CSS to use `display: inline` will cause this element to only occupy the width of the text. 

![image](https://github.com/pypi/inspector/assets/128343390/76c38191-d91d-4cb6-8535-969b29278f0b)

