### PR TITLE
chore: removed dev.txt dependancies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,5 @@ jobs:
         run: |
           pip install -U pip setuptools wheel
           pip install -r requirements.txt --no-deps
-          pip install -r requirements/dev.txt
       - name: Run ${{ matrix.name }}
         run: ${{ matrix.command }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,6 @@ RUN pip install \
 # Install development dependencies
 RUN if [ "$DEVEL" = "yes" ]; then pip install -r requirements/lint.txt; fi
 RUN if [ "$DEVEL" = "yes" ]; then pip install -r requirements/tests.txt; fi
-RUN if [ "$DEVEL" = "yes" ]; then pip install -r requirements/dev.txt; fi
 
 # Copy in everything else
 COPY . .

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,0 @@
-black
-isort
-pretend
-pytest


### PR DESCRIPTION
Fixes: #169

Removing the explicit dep definition from dev.txt as all the deps are now present in the `/requirements` folder.