### PR TITLE
Focus the project input when "/" is pressed

### DIFF
--- a/inspector/static/inspector.js
+++ b/inspector/static/inspector.js
@@ -1,0 +1,10 @@
+document.addEventListener("keydown", (e) => {
+  if (e.key !== "/" || e.ctrlKey || e.metaKey || e.altKey) return;
+  const t = e.target;
+  if (t instanceof HTMLInputElement || t instanceof HTMLTextAreaElement || (t instanceof HTMLElement && t.isContentEditable)) return;
+  const input = document.getElementById("project-input");
+  if (!input) return;
+  e.preventDefault();
+  input.focus();
+  input.select();
+});

--- a/inspector/templates/base.html
+++ b/inspector/templates/base.html
@@ -3,15 +3,16 @@
     {% block head %}{% endblock %}
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🕵️</text></svg>">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="/static/inspector.js" defer></script>
   </head>
   <body>
     <main>
       <h1><a href="/">Inspector</a></h1>
       <form action="/">
         {% if h2 %}
-          <input type="text" name="project" placeholder="Project name" value="{{ h2 }}" autocomplete="off">
+          <input id="project-input" type="text" name="project" placeholder="Project name" value="{{ h2 }}" autocomplete="off">
         {% else %}
-          <input type="text" name="project" placeholder="Project name" autocomplete="off">
+          <input id="project-input" type="text" name="project" placeholder="Project name" autocomplete="off">
         {% endif %}
         <input type="submit">
       </form>


### PR DESCRIPTION
This has been driving me nuts for literally years -- PyPI will focus the search when you type `/`, so I think the inspector service should too 🙂 

(I did this in plain, open-coded JS for simplicity's sake.)