### PR TITLE
chore(dev): prevent loading venv in dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .state/
+.venv
 __pycache__/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,15 @@ services:
     env_file: dev/environment
     volumes:
       - .:/app/
+      # Neat hack to prevent actually mounting the venv into the container.
+      - type: volume
+        source: venv
+        target: /app/.venv
     ports:
       - "80:8080"
     #links:
     #  - db
+
+volumes:
+  venv:
+


### PR DESCRIPTION
Without this, `make lint` will run against the local `.venv` directory and produce noisy results.